### PR TITLE
Remove invalid $schema key

### DIFF
--- a/syntaxes/sourcepawn.tmLanguage.json
+++ b/syntaxes/sourcepawn.tmLanguage.json
@@ -1,5 +1,4 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "SourcePawn",
 	"patterns": [
 		{


### PR DESCRIPTION
The `$schema` key isn't recognised by [Linguist's](https://github.com/github/linguist) grammar compiler, stopping this grammar from being used to syntax highlight SourcePawn files on GitHub.com. The same solution was used for Type Language (https://github.com/goodmind/language-typelanguage/pull/2) as comments are not valid either.
```
$ script/grammar-compiler add vendor/grammars/sourcepawn-vscode
  > latest: Pulling from linguist/grammar-compiler
  > Digest: sha256:2c49232d2c7c06974c2908fe613630c3bb876f0742a12520440a1a4f98aa2e42
  > Status: Image is up to date for linguist/grammar-compiler:latest
  > The new grammar repository `vendor/grammars/sourcepawn-vscode` (from https://github.c om/Dreae/sourcepawn-vscode) contains 1 errors:
  >     - Unknown keys in grammar: `source.sourcepawn` (in `syntaxes/sourcepawn.tmLanguag e.json`) contains invalid keys (`$schema`)
  >
  > failed to compile the given grammar
Command failed. Aborting.
```